### PR TITLE
Fix wrong uniform name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glium_text"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Text drawing with glium and freetype"
 keywords = ["text", "opengl"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,10 +275,10 @@ impl TextSystem {
 
                         varying vec2 v_tex_coords;
                         uniform vec4 color;
-                        uniform sampler2D texture;
+                        uniform sampler2D tex;
 
                         void main() {
-                            gl_FragColor = vec4(color.rgb, color.a * texture2D(texture, v_tex_coords));
+                            gl_FragColor = vec4(color.rgb, color.a * texture2D(tex, v_tex_coords));
                             if (gl_FragColor.a <= 0.01) {
                                 discard;
                             }
@@ -432,7 +432,7 @@ pub fn draw<F, S, M>(text: &TextDisplay<F>, system: &TextSystem, target: &mut S,
     let uniforms = uniform! {
         matrix: matrix,
         color: color,
-        texture: glium::uniforms::Sampler(&texture.texture, glium::uniforms::SamplerBehavior {
+        tex: glium::uniforms::Sampler(&texture.texture, glium::uniforms::SamplerBehavior {
             magnify_filter: glium::uniforms::MagnifySamplerFilter::Linear,
             minify_filter: glium::uniforms::MinifySamplerFilter::Linear,
             .. Default::default()


### PR DESCRIPTION
The example works by chance. Glium doesn't warn you when you're missing uniforms since uniforms can have default values.
