### PR TITLE
Update to glium to 0.13, cgmath to 0.7 and fixed examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ rust:
  - stable
  - nightly
 
-install:
-    - sudo apt-get install libXxf86vm-dev libosmesa6-dev
+addons:
+  apt:
+    packages:
+    - libxxf86vm-dev
+    - libosmesa6-dev
 
 after_success:
     - |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,12 @@ freetype-sys = "0.2"
 libc = "0.2"
 
 [dependencies.glium]
-version = "0.12"
+version = "0.13"
 default-features = false
-features = ["cgmath"]
 
 [dev-dependencies]
-cgmath = "0.2"
+cgmath = "0.7"
 
 [dev-dependencies.glium]
-version = "0.12"
+version = "0.13"
 features = ["glutin"]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -4,7 +4,6 @@ extern crate cgmath;
 
 use std::thread;
 use std::time::Duration;
-use cgmath::FixedArray;
 use glium::Surface;
 use glium::glutin;
 
@@ -25,16 +24,16 @@ fn main() {
     'main: loop {
         let (w, h) = display.get_framebuffer_dimensions();
 
-        let matrix = cgmath::Matrix4::new(
+        let matrix:[[f32; 4]; 4] = cgmath::Matrix4::new(
             2.0 / text_width, 0.0, 0.0, 0.0,
             0.0, 2.0 * (w as f32) / (h as f32) / text_width, 0.0, 0.0,
             0.0, 0.0, 1.0, 0.0,
             -1.0, -1.0, 0.0, 1.0f32,
-        );
+        ).into();
 
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 1.0);
-        glium_text::draw(&text, &system, &mut target, matrix.into_fixed(), (1.0, 1.0, 0.0, 1.0));
+        glium_text::draw(&text, &system, &mut target, matrix, (1.0, 1.0, 0.0, 1.0));
         target.finish().unwrap();
 
         thread::sleep(sleep_duration);

--- a/examples/user_text.rs
+++ b/examples/user_text.rs
@@ -5,7 +5,6 @@ extern crate cgmath;
 use std::path::Path;
 use std::thread;
 use std::time::Duration;
-use cgmath::FixedArray;
 use glium::Surface;
 use glium::glutin;
 
@@ -37,16 +36,16 @@ fn main() {
 
         let (w, h) = display.get_framebuffer_dimensions();
 
-        let matrix = cgmath::Matrix4::new(
+        let matrix:[[f32; 4]; 4] = cgmath::Matrix4::new(
             0.1, 0.0, 0.0, 0.0,
             0.0, 0.1 * (w as f32) / (h as f32), 0.0, 0.0,
             0.0, 0.0, 1.0, 0.0,
             -0.9, 0.0, 0.0, 1.0f32,
-        );
+        ).into();
 
         let mut target = display.draw();
         target.clear_color(0.0, 0.0, 0.0, 1.0);
-        glium_text::draw(&text, &system, &mut target, matrix.into_fixed(), (1.0, 1.0, 0.0, 1.0));
+        glium_text::draw(&text, &system, &mut target, matrix, (1.0, 1.0, 0.0, 1.0));
         target.finish().unwrap();
 
         thread::sleep(sleep_duration);


### PR DESCRIPTION
Updated glium to 0.13.

Due to build errors with the examples updated cgmath to 0.7 and made changes to fix them.
