### PR TITLE
Update glium dependency to 0.26.0-alpha1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ freetype-sys = "0.7"
 libc = "0.2"
 
 [dependencies.glium]
-version = "0.25"
+version = "0.26.0-alpha1"
 default-features = false
 
 [dev-dependencies]
 cgmath = "0.16"
 
 [dev-dependencies.glium]
-version = "0.25"
+version = "0.26.0-alpha1"
 features = ["glutin"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ freetype-sys = "0.7"
 libc = "0.2"
 
 [dependencies.glium]
-version = "0.23"
+version = "0.25"
 default-features = false
 
 [dev-dependencies]
 cgmath = "0.16"
 
 [dev-dependencies.glium]
-version = "0.23"
+version = "0.25"
 features = ["glutin"]


### PR DESCRIPTION
I know this crate isn't really managed too much anymore but this was a simple upgrade and both examples seem to work fine.